### PR TITLE
exclude html encoding of quotes when parsing html

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+2.1.2
+=====
+
+*   single and double quotes can won't be encoded anymore in content meaning content can now be a json string in `HTMLElement`s.
+
 2.1.1
 =====
 

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
         "php": "^7.2"
     },
     "require-dev": {
-        "becklyn/php-cs": "^2.0.2"
+        "becklyn/php-cs": "^2.0.2",
+        "symfony/phpunit-bridge": "^4.3.8"
     },
     "config": {
         "sort-packages": true

--- a/src/Builder/HtmlBuilder.php
+++ b/src/Builder/HtmlBuilder.php
@@ -36,7 +36,7 @@ class HtmlBuilder
             }
             else
             {
-                $content[] = \htmlspecialchars($entry);
+                $content[] = \htmlspecialchars($entry, \ENT_NOQUOTES);
             }
         }
 

--- a/tests/Builder/HtmlBuilderTest.php
+++ b/tests/Builder/HtmlBuilderTest.php
@@ -53,6 +53,10 @@ class HtmlBuilderTest extends TestCase
                 new HtmlElement("p", [], ["a ", new SafeMarkup("This is <b>bold</b>!"), " c"]),
                 '<p>a This is <b>bold</b>! c</p>',
             ],
+            [
+                new HtmlElement("script", ["type" =>"application/json"], ['{"foo": "bar"}']),
+                '<script type="application/json">{"foo": "bar"}</script>',
+            ],
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| Improvement?  | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Docs PR       | **missing**

This is to enable the possibility to parse a json string as content.
